### PR TITLE
Add theme and loading overlay for cohesive UI

### DIFF
--- a/SpiderLeague/App.tsx
+++ b/SpiderLeague/App.tsx
@@ -5,6 +5,8 @@ import { View, StyleSheet, Alert } from 'react-native';
 // import { apiService } from './src/services/api';
 import { demoApiService as apiService } from './src/services/demo-api';
 import { User, Spider } from './src/types';
+import LoadingOverlay from './src/components/LoadingOverlay';
+import { colors } from './src/theme';
 
 // Screens
 import LoginScreen from './src/screens/LoginScreen';
@@ -87,11 +89,7 @@ export default function App() {
   };
 
   if (loading) {
-    return (
-      <View style={styles.container}>
-        <StatusBar style="light" />
-      </View>
-    );
+    return <LoadingOverlay />;
   }
 
   const renderScreen = () => {
@@ -171,6 +169,6 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a1a',
+    backgroundColor: colors.background,
   },
 });

--- a/SpiderLeague/src/components/LoadingOverlay.tsx
+++ b/SpiderLeague/src/components/LoadingOverlay.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { colors } from '../theme';
+
+export default function LoadingOverlay() {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+  },
+});

--- a/SpiderLeague/src/screens/HomeScreen.tsx
+++ b/SpiderLeague/src/screens/HomeScreen.tsx
@@ -10,6 +10,8 @@ import {
 } from 'react-native';
 import { demoApiService as apiService } from '../services/demo-api';
 import { User, League } from '../types';
+import LoadingOverlay from '../components/LoadingOverlay';
+import { colors } from '../theme';
 
 interface HomeScreenProps {
   user: User;
@@ -68,8 +70,12 @@ export default function HomeScreen({ user, onNavigate, onLogout }: HomeScreenPro
     );
   };
 
+  if (!league || !stats) {
+    return <LoadingOverlay />;
+  }
+
   return (
-    <ScrollView 
+    <ScrollView
       style={styles.container}
       refreshControl={
         <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
@@ -180,7 +186,7 @@ export default function HomeScreen({ user, onNavigate, onLogout }: HomeScreenPro
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a1a',
+    backgroundColor: colors.background,
   },
   header: {
     flexDirection: 'row',
@@ -192,27 +198,27 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#ff6b35',
+    color: colors.primary,
   },
   logoutButton: {
     padding: 8,
   },
   logoutText: {
-    color: '#ff6b35',
+    color: colors.primary,
     fontSize: 16,
   },
   profileCard: {
-    backgroundColor: '#2a2a2a',
+    backgroundColor: colors.card,
     margin: 20,
     padding: 20,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: '#3a3a3a',
+    borderColor: colors.border,
   },
   username: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#ffffff',
+    color: colors.text,
     textAlign: 'center',
     marginBottom: 16,
   },
@@ -231,37 +237,37 @@ const styles = StyleSheet.create({
   statValue: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#ffffff',
+    color: colors.text,
   },
   statLabel: {
     fontSize: 12,
-    color: '#cccccc',
+     color: colors.textSecondary,
     marginTop: 4,
   },
   battleStats: {
     alignItems: 'center',
   },
   battleText: {
-    color: '#cccccc',
+    color: colors.textSecondary,
     fontSize: 14,
   },
   leagueCard: {
-    backgroundColor: '#2a2a2a',
+    backgroundColor: colors.card,
     marginHorizontal: 20,
     marginBottom: 20,
     padding: 20,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: '#3a3a3a',
+    borderColor: colors.border,
   },
   cardTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#ffffff',
+    color: colors.text,
     marginBottom: 8,
   },
   leagueDescription: {
-    color: '#cccccc',
+    color: colors.textSecondary,
     fontSize: 14,
     marginBottom: 12,
   },
@@ -269,28 +275,28 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   leagueText: {
-    color: '#ff6b35',
+    color: colors.primary,
     fontSize: 16,
     fontWeight: 'bold',
   },
   leagueButton: {
-    backgroundColor: '#3a3a3a',
+    backgroundColor: colors.border,
     padding: 12,
     borderRadius: 8,
     alignItems: 'center',
   },
   leagueButtonText: {
-    color: '#ff6b35',
+    color: colors.primary,
     fontWeight: 'bold',
   },
   quickStats: {
-    backgroundColor: '#2a2a2a',
+    backgroundColor: colors.card,
     marginHorizontal: 20,
     marginBottom: 20,
     padding: 20,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: '#3a3a3a',
+    borderColor: colors.border,
   },
   statsGrid: {
     flexDirection: 'row',
@@ -302,11 +308,11 @@ const styles = StyleSheet.create({
   quickStatValue: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#ff6b35',
+    color: colors.primary,
   },
   quickStatLabel: {
     fontSize: 12,
-    color: '#cccccc',
+    color: colors.textSecondary,
     marginTop: 4,
   },
   actionButtons: {
@@ -319,22 +325,22 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   primaryButton: {
-    backgroundColor: '#ff6b35',
+    backgroundColor: colors.primary,
   },
   secondaryButton: {
-    backgroundColor: '#2a2a2a',
+    backgroundColor: colors.card,
     borderWidth: 1,
-    borderColor: '#3a3a3a',
+    borderColor: colors.border,
     flex: 1,
     marginHorizontal: 6,
   },
   actionButtonText: {
-    color: '#ffffff',
+    color: colors.text,
     fontSize: 18,
     fontWeight: 'bold',
   },
   secondaryButtonText: {
-    color: '#ff6b35',
+    color: colors.primary,
     fontSize: 16,
     fontWeight: 'bold',
   },

--- a/SpiderLeague/src/screens/LoginScreen.tsx
+++ b/SpiderLeague/src/screens/LoginScreen.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
 } from 'react-native';
 import { demoApiService as apiService } from '../services/demo-api';
+import { colors } from '../theme';
 
 interface LoginScreenProps {
   onLogin: (user: any) => void;
@@ -39,8 +40,8 @@ export default function LoginScreen({ onLogin, onSwitchToRegister }: LoginScreen
   };
 
   return (
-    <KeyboardAvoidingView 
-      style={styles.container} 
+    <KeyboardAvoidingView
+      style={styles.container}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
       <View style={styles.header}>
@@ -98,7 +99,7 @@ export default function LoginScreen({ onLogin, onSwitchToRegister }: LoginScreen
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a1a',
+    backgroundColor: colors.background,
     justifyContent: 'center',
     padding: 20,
   },
@@ -109,28 +110,28 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 36,
     fontWeight: 'bold',
-    color: '#ff6b35',
+    color: colors.primary,
     marginBottom: 8,
   },
   subtitle: {
     fontSize: 16,
-    color: '#cccccc',
+    color: colors.textSecondary,
   },
   form: {
     marginBottom: 40,
   },
   input: {
-    backgroundColor: '#2a2a2a',
+    backgroundColor: colors.card,
     borderRadius: 8,
     padding: 16,
     marginBottom: 16,
-    color: '#ffffff',
+    color: colors.text,
     fontSize: 16,
     borderWidth: 1,
-    borderColor: '#3a3a3a',
+    borderColor: colors.border,
   },
   button: {
-    backgroundColor: '#ff6b35',
+    backgroundColor: colors.primary,
     borderRadius: 8,
     padding: 16,
     alignItems: 'center',
@@ -140,7 +141,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#cc5529',
   },
   buttonText: {
-    color: '#ffffff',
+    color: colors.text,
     fontSize: 16,
     fontWeight: 'bold',
   },
@@ -148,7 +149,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   linkText: {
-    color: '#ff6b35',
+    color: colors.primary,
     fontSize: 16,
   },
   footer: {

--- a/SpiderLeague/src/screens/RegisterScreen.tsx
+++ b/SpiderLeague/src/screens/RegisterScreen.tsx
@@ -11,6 +11,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { demoApiService as apiService } from '../services/demo-api';
+import { colors } from '../theme';
 
 interface RegisterScreenProps {
   onRegister: (user: any) => void;
@@ -148,7 +149,7 @@ export default function RegisterScreen({ onRegister, onSwitchToLogin }: Register
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a1a',
+    backgroundColor: colors.background,
   },
   scrollContent: {
     flexGrow: 1,
@@ -162,26 +163,26 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 32,
     fontWeight: 'bold',
-    color: '#ff6b35',
+    color: colors.primary,
     marginBottom: 8,
   },
   subtitle: {
     fontSize: 16,
-    color: '#cccccc',
+    color: colors.textSecondary,
     textAlign: 'center',
   },
   form: {
     marginBottom: 40,
   },
   input: {
-    backgroundColor: '#2a2a2a',
+    backgroundColor: colors.card,
     borderRadius: 8,
     padding: 16,
     marginBottom: 16,
-    color: '#ffffff',
+    color: colors.text,
     fontSize: 16,
     borderWidth: 1,
-    borderColor: '#3a3a3a',
+    borderColor: colors.border,
   },
   regionInfo: {
     backgroundColor: '#2a4a2a',
@@ -198,11 +199,11 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   regionSubtext: {
-    color: '#cccccc',
+    color: colors.textSecondary,
     fontSize: 14,
   },
   button: {
-    backgroundColor: '#ff6b35',
+    backgroundColor: colors.primary,
     borderRadius: 8,
     padding: 16,
     alignItems: 'center',
@@ -212,7 +213,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#cc5529',
   },
   buttonText: {
-    color: '#ffffff',
+    color: colors.text,
     fontSize: 16,
     fontWeight: 'bold',
   },
@@ -220,7 +221,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   linkText: {
-    color: '#ff6b35',
+    color: colors.primary,
     fontSize: 16,
   },
   footer: {

--- a/SpiderLeague/src/theme.ts
+++ b/SpiderLeague/src/theme.ts
@@ -1,0 +1,18 @@
+export const colors = {
+  background: '#1a1a1a',
+  card: '#2a2a2a',
+  border: '#3a3a3a',
+  primary: '#ff6b35',
+  text: '#ffffff',
+  textSecondary: '#cccccc',
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 20,
+  xl: 24,
+};
+
+export default { colors, spacing };


### PR DESCRIPTION
## Summary
- establish shared color palette and spacing in `src/theme.ts`
- add `LoadingOverlay` component for full-screen activity indicators
- apply theme and loading overlay across App, Home, Login, and Register screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae1aede16c83218d20a861223b0fcb